### PR TITLE
Models coords option

### DIFF
--- a/bt-target/client/main.lua
+++ b/bt-target/client/main.lua
@@ -46,6 +46,9 @@ function playerTargetEnable()
                         for k , v in ipairs(Models[_]["job"]) do 
                             if v == "all" or v == PlayerJob.name then
                                 if _ == GetEntityModel(entity) then
+				    if Models[_]["coords"] ~= nil then
+                                        coords = Models[_]["coords"]
+                                    end
                                     if #(plyCoords - coords) <= Models[_]["distance"] then
 
                                         success = true


### PR DESCRIPTION
This adds a coords option for models to stop the same model being targeted elsewhere.
It can be left empty to make the selected model be targeted everywhere

Example: https://gyazo.com/c8e71a59196681c2613d0944c4ae0b3d