### PR TITLE
Ultrawide support.

### DIFF
--- a/bt-target/html/css/style.css
+++ b/bt-target/html/css/style.css
@@ -1,3 +1,7 @@
+body {
+    overflow: hidden;
+}
+
 .target-wrapper {
     display: none;
 }
@@ -12,10 +16,12 @@
 
 .target-label-wrapper {
     position: absolute;
-    right: 80vh;
-    top: 52vh;
-    margin-top: -13px;
-    width: 11vh;
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    margin-top: 28px;
 }
 
 .target-label {
@@ -27,6 +33,8 @@
     text-transform: uppercase;
     user-select: none;
     white-space: nowrap;
+    display: flex;
+    align-self: center;
 }
 
 .target-icon {


### PR DESCRIPTION
Previously target-label appeared off when using an ultrawide monitor. 
Styled it with flex to get a better position.